### PR TITLE
Add tables creation

### DIFF
--- a/creation/parking.sql
+++ b/creation/parking.sql
@@ -1,0 +1,16 @@
+create table
+  public.parking (
+    id uuid not null default gen_random_uuid (),
+    created_at timestamp with time zone not null default now(),
+    parking_name text not null,
+    image text null,
+    address text not null,
+    phone text null,
+    geolocation geography not null,
+    total_slot bigint not null default '0'::bigint,
+    available_slot bigint not null default '0'::bigint,
+    price_per_day double precision null,
+    price_per_month double precision null,
+    price_per_year double precision null,
+    constraint parking_pkey primary key (id)
+  ) tablespace pg_default;

--- a/creation/parking_employee.sql
+++ b/creation/parking_employee.sql
@@ -1,0 +1,13 @@
+create table
+  public.parking_employee (
+    id uuid not null default gen_random_uuid (),
+    profile_id uuid not null default gen_random_uuid (),
+    working_start_time time with time zone null,
+    working_end_time time with time zone null,
+    created_at timestamp with time zone not null default now(),
+    parking_id uuid not null default gen_random_uuid (),
+    currency_locale text null default 'vi_VN'::text,
+    constraint parking_employee_pkey primary key (id),
+    constraint parking_employee_parking_id_fkey foreign key (parking_id) references parking (id),
+    constraint parking_employee_profile_id_fkey foreign key (profile_id) references profile (id)
+  ) tablespace pg_default;

--- a/creation/parking_owner.sql
+++ b/creation/parking_owner.sql
@@ -1,0 +1,11 @@
+create table
+  public.parking_owner (
+    id uuid not null default gen_random_uuid (),
+    parking_id uuid not null default gen_random_uuid (),
+    profile_id uuid not null default gen_random_uuid (),
+    currency_locale text not null default 'vi_VN'::text,
+    created_at timestamp with time zone not null default now(),
+    constraint parking_owner_pkey primary key (id),
+    constraint parking_owner_parking_id_fkey foreign key (parking_id) references parking (id),
+    constraint parking_owner_profile_id_fkey foreign key (profile_id) references profile (id)
+  ) tablespace pg_default;

--- a/creation/parking_shift_price.sql
+++ b/creation/parking_shift_price.sql
@@ -1,0 +1,12 @@
+create table
+  public.parking_shift_price (
+    id uuid not null default gen_random_uuid (),
+    parking_id uuid not null default gen_random_uuid (),
+    price double precision not null,
+    start_time time without time zone not null,
+    end_time time without time zone not null,
+    created_at timestamp with time zone not null default now(),
+    shift_type public.shift_type not null,
+    constraint parking_shift_price_pkey primary key (id),
+    constraint parking_shift_price_parking_id_fkey foreign key (parking_id) references parking (id)
+  ) tablespace pg_default;

--- a/creation/parking_specific_address.sql
+++ b/creation/parking_specific_address.sql
@@ -1,0 +1,11 @@
+create table
+  public.parking_specific_address (
+    id uuid not null default gen_random_uuid (),
+    created_at timestamp with time zone not null default now(),
+    ward text not null,
+    district text not null,
+    city text not null,
+    country text not null,
+    constraint parking_specific_address_pkey primary key (id),
+    constraint parking_specific_address_id_fkey foreign key (id) references parking (id)
+  ) tablespace pg_default;

--- a/creation/profile.sql
+++ b/creation/profile.sql
@@ -1,0 +1,16 @@
+create table
+  public.profile (
+    id uuid not null default gen_random_uuid (),
+    created_at timestamp with time zone not null default now(),
+    email text not null,
+    phone text null,
+    full_name text null,
+    display_name text null,
+    avatar text null,
+    type public.user_type not null default 'user'::user_type,
+    dob date null,
+    gender public.gender null,
+    favorite_parking uuid[] null,
+    constraint profile_pkey primary key (id),
+    constraint profile_id_fkey foreign key (id) references auth.users (id)
+  ) tablespace pg_default;

--- a/creation/ticket.sql
+++ b/creation/ticket.sql
@@ -1,0 +1,21 @@
+create table
+  public.ticket (
+    id uuid not null default gen_random_uuid (),
+    start_time timestamp with time zone not null,
+    end_time timestamp with time zone not null,
+    days bigint not null,
+    hours bigint not null,
+    total double precision not null,
+    status public.ticket_status not null,
+    created_at timestamp with time zone not null default now(),
+    user_id uuid not null default gen_random_uuid (),
+    parking_id uuid not null default gen_random_uuid (),
+    vehicle_id uuid not null default gen_random_uuid (),
+    payment_intent_id text null,
+    entry_time timestamp with time zone null,
+    exit_time timestamp with time zone null,
+    constraint ticket_pkey primary key (id),
+    constraint ticket_parking_id_fkey foreign key (parking_id) references parking (id),
+    constraint ticket_user_id_fkey foreign key (user_id) references profile (id),
+    constraint ticket_vehicle_id_fkey foreign key (vehicle_id) references vehicle (id)
+  ) tablespace pg_default;

--- a/creation/vehicle.sql
+++ b/creation/vehicle.sql
@@ -1,0 +1,10 @@
+create table
+  public.vehicle (
+    id uuid not null default gen_random_uuid (),
+    user_id uuid not null default gen_random_uuid (),
+    vehicle_name text not null,
+    license_plate text not null,
+    created_at timestamp with time zone not null default now(),
+    constraint vehicle_pkey primary key (id),
+    constraint vehicle_user_id_fkey foreign key (user_id) references profile (id)
+  ) tablespace pg_default;


### PR DESCRIPTION
# Summary
This pull request introduces several new database tables to support a parking management system. The changes include the creation of tables for parking, parking employees, parking owners, parking shift prices, parking specific addresses, profiles, tickets, and vehicles.

New table creations:

* [`creation/parking.sql`](diffhunk://#diff-c4e40c55e61078ed113c8f6c9c93d4bc863434531d07e27c08d7092ab3ff74eaR1-R16): Created `parking` table with columns for parking details such as name, address, geolocation, and pricing.
* [`creation/parking_employee.sql`](diffhunk://#diff-11da33ea5e457897dc2f4e0c5b0548ac6199465ac4207c303c60e91ff4b606bfR1-R13): Created `parking_employee` table with columns for employee details, including working hours and references to the `parking` and `profile` tables.
* [`creation/parking_owner.sql`](diffhunk://#diff-c01468b90f2092b7277142f7957d97565e1790067c1cfda343032a8902ab0879R1-R11): Created `parking_owner` table with columns for owner details and references to the `parking` and `profile` tables.
* [`creation/parking_shift_price.sql`](diffhunk://#diff-9daf02e1384edbb366acde67b2714e8017f95007abafcb0a7c0f9d6ef1f1754cR1-R12): Created `parking_shift_price` table with columns for shift pricing details and references to the `parking` table.
* [`creation/parking_specific_address.sql`](diffhunk://#diff-26b58a761af097c8614d8481701eea535f40e3cfdb5b95f542eee14f19d9b6cfR1-R11): Created `parking_specific_address` table with columns for specific address details and a reference to the `parking` table.
* [`creation/profile.sql`](diffhunk://#diff-6cb6e8033bb654157b1282d13703b0c7ceba8fe33bf5996412c6a9e67a11ec77R1-R16): Created `profile` table with columns for user profile details and a reference to the `auth.users` table.
* [`creation/ticket.sql`](diffhunk://#diff-ae9cb4c14fd45b589805484a0b8fb28014169ad14456925d3fcdb5f9d750baa7R1-R21): Created `ticket` table with columns for ticket details, including time, status, and references to the `parking`, `profile`, and `vehicle` tables.
* [`creation/vehicle.sql`](diffhunk://#diff-ba0e4969ee59e35c33f2003c444a3b9e5d794af884ee50024bb8f55f6c7de153R1-R10): Created `vehicle` table with columns for vehicle details and a reference to the `profile` table.